### PR TITLE
Now using getCmdAndArgs. Fixes #4

### DIFF
--- a/lib/linter-pylint.coffee
+++ b/lib/linter-pylint.coffee
@@ -32,7 +32,11 @@ class LinterPylint extends Linter
 
   lintFile: (filePath, callback) =>
     if @enabled # disabled if the lint-executable is not reachable - see initialization
-      exec @getCmd(filePath), {cwd: @cwd}, (error, stdout, stderr) =>
+      command = @getCmdAndArgs(filePath).command +
+        ' ' +
+        @getCmdAndArgs(filePath).args.join(' ')
+
+      exec command, {cwd: @cwd}, (error, stdout, stderr) =>
         @processMessage(stdout, callback)
 
 module.exports = LinterPylint


### PR DESCRIPTION
Wrote a fix for #4. We are now using `getCmdAndArgs` and concatenate the results into a string, which is later sent to `exec`, just like before.

Let me know if you want me to open the PR to another branch.
