### PR TITLE
Use project root as cwd

### DIFF
--- a/lib/linter-pylint.coffee
+++ b/lib/linter-pylint.coffee
@@ -16,7 +16,7 @@ class LinterPylint extends Linter
   constructor: (@editor) ->
     super @editor  # sets @cwd to the dirname of the current file
     # if we're in a project, use that path instead
-    @cwd = atom.project.path || @cwd
+    @cwd = atom.project.path ? @cwd
     exec 'pylint --version', cwd: @cwd, @executionCheckHandler
     console.log 'Linter-Pylint: initialization completed'
 


### PR DESCRIPTION
I have a pylintrc file in my project root that wasn't being found by
`linter-pylint`. Looking into it, I discovered `@cwd` was `null` because
`LinterPylint.constructor` never calls `super`.

Test Plan:
Opened a new Atom window in the directory that contains my pylintrc file and
had pylint import things properly.
