### PR TITLE
Respect linter.lintDebug config

### DIFF
--- a/lib/linter-pylint.coffee
+++ b/lib/linter-pylint.coffee
@@ -37,6 +37,9 @@ class LinterPylint extends Linter
         @getCmdAndArgs(filePath).args.join(' ')
 
       exec command, {cwd: @cwd}, (error, stdout, stderr) =>
+        if atom.config.get('linter.lintDebug')
+          console.warn 'stderr', stderr
+          console.log 'stdout', stdout
         @processMessage(stdout, callback)
 
 module.exports = LinterPylint


### PR DESCRIPTION
While debugging I wanted to see the output of the linter. It seems `Linter`
allows for this, but `LinterPylint` does not. Until now.

Test Plan:
1. atom.config.set('linter.lintDebug', true)
2. Reloaded my Atom window

Then I saw pylint output in the console.
