### PR TITLE
Show message ids in lint messages

### DIFF
--- a/lib/linter-pylint.coffee
+++ b/lib/linter-pylint.coffee
@@ -10,7 +10,9 @@ class LinterPylint extends Linter
 
   linterName: 'pylint'
 
-  regex: '^(?<line>\\d+),(?<col>\\d+),((?<error>error)|(?<warning>warning)),(?<message>.*)$'
+  regex: '^(?<line>\\d+),(?<col>\\d+),' +
+         '((?<error>error)|(?<warning>warning)),' +
+         '(?<msg_id>\\w\\d+):\\s(?<message>.*)$'
   regexFlags: 'm'
 
   constructor: (@editor) ->
@@ -41,5 +43,8 @@ class LinterPylint extends Linter
           console.warn 'stderr', stderr
           console.log 'stdout', stdout
         @processMessage(stdout, callback)
+
+  formatMessage: (match) ->
+    "#{match.msg_id}: #{match.message}"
 
 module.exports = LinterPylint


### PR DESCRIPTION
This is useful because these ids are needed so you can turn off messages you
don't like. It also makes searching for more information about lint messages
easier.

In the future it'd be nice to be able to right click a lint message, click
'don't show again' and have linter-pylint update the project's pylintrc. But
this will do for now.

Test Plan:
Reloaded my Atom project and verified that ids are prepended to lint messages
