### PR TITLE
fix #13

### DIFF
--- a/lib/linter-pylint.coffee
+++ b/lib/linter-pylint.coffee
@@ -28,14 +28,14 @@ class LinterPylint extends Linter
   # Private: handles the initial 'version' call, extracts the version and
   # enables the linter
   executionCheckHandler: (error, stdout, stderr) =>
-    versionRegEx = /pylint ([\d\.]+)\,/
+    versionRegEx = /pylint(-script.py)? ([\d\.]+)\,/
     if not versionRegEx.test(stdout)
       result = if error? then '#' + error.code + ': ' else ''
       result += 'stdout: ' + stdout if stdout.length > 0
       result += 'stderr: ' + stderr if stderr.length > 0
       console.error "Linter-Pylint: 'pylint' was not executable: " + result
     else
-      log "Linter-Pylint: found pylint " + versionRegEx.exec(stdout)[1]
+      log "Linter-Pylint: found pylint " + versionRegEx.exec(stdout).slice(-1)[0]
       @enabled = true # everything is fine, the linter is ready to work
 
   lintFile: (filePath, callback) =>


### PR DESCRIPTION
Regex now matches strings like `pylint 1.2.3` and `pylint-script.py 1.2.3`

Test:
http://coffeescript.org/#try:input1%20%3D%20'pylint%201.3.0%2C'%0Ainput2%20%3D%20'pylint-script.py%201.3.0%2C'%0A%0AversionRegEx%20%3D%20%2Fpylint(-script.py)%3F%20(%5B%5Cd%5C.%5D%2B)%5C%2C%2F%0A%0Aresult1%20%3D%20versionRegEx.exec(input1).slice(-1)%5B0%5D%0Aresult2%20%3D%20versionRegEx.exec(input2).slice(-1)%5B0%5D%0A%0Aalert%20result1%20%2B%20'%20%7C%20'%20%2B%20result2

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/atomlinter/linter-pylint/19)

<!-- Reviewable:end -->
