### PR TITLE
Make sure output is text

### DIFF
--- a/lib/linter-pylint.coffee
+++ b/lib/linter-pylint.coffee
@@ -34,6 +34,7 @@ class LinterPylint extends Linter
     cmd = [atom.config.get 'linter-pylint.executable']
     cmd.push "--msg-template='{line},{column},{category},{msg_id}:{msg}'"
     cmd.push '--reports=n'
+    cmd.push '--output-format=text'
 
     rcFile = atom.config.get 'linter-pylint.rcFile'
     if rcFile


### PR DESCRIPTION
`output-format=color`, for example, will quietly break the package. No errors will appear in the console, but no messages will be displayed.

Longer term, it might be nice to update the regex to us `output-format=parseable`, and to log an error if we appear to be getting bad error strings in stdout.