### PR TITLE
Fix the ENOTDIR error if atom.project.path is a file instead of a direct...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.log
 node_modules/
 *.py
+.npmignore

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ There are other linters available - take a look at the linters [mainpage](https:
 
 ## Changelog
 
+### 0.2.1
+ - Fix the ENOTDIR error if atom.project.path is a file instead of a directory
+
 ### 0.2.0
  - Settings to configure rcfile, executable name [#24](https://github.com/AtomLinter/linter-pylint/pull/24)
 

--- a/lib/linter-pylint.coffee
+++ b/lib/linter-pylint.coffee
@@ -1,3 +1,4 @@
+fs = require 'fs'
 {exec} = require 'child_process'
 linterPath = atom.packages.getLoadedPackage("linter").path
 Linter = require "#{linterPath}/lib/linter"
@@ -17,9 +18,11 @@ class LinterPylint extends Linter
   constructor: (@editor) ->
     super @editor
 
-    # sets @cwd to the dirname of the current file
-    # if we're in a project, use that path instead
-    @cwd = atom.project.path ? @cwd
+    stats = fs.statSync atom.project.path
+    if stats.isDirectory()
+      # sets @cwd to the dirname of the current file
+      # if we're in a project, use that path instead
+      @cwd = atom.project.path
 
     # Set to observe config options
     atom.config.observe 'linter-pylint.executable', => @updateCommand()

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "linter-package": true,
   "activationEvents": [],
   "main": "./lib/init",
-  "version": "0.2.0",
+  "version": "0.2.1 ",
   "description": "Lint python on the fly, using pylint",
   "repository": "https://github.com/AtomLinter/linter-pylint",
   "license": "MIT",


### PR DESCRIPTION
Hi, can you merge this pull request as this error appears a lot on the issue list of AtomLinter instead of linter-pylint. If the "project" is a file instead of a whole directory Atom returns a file instead of a directory which results in filling 'cwd' with the complete file path instead of the directory path.