### PR TITLE
Cleanup current deprecations

### DIFF
--- a/lib/linter-pylint.coffee
+++ b/lib/linter-pylint.coffee
@@ -24,12 +24,12 @@ class LinterPylint extends Linter
     @cwd = paths[0] || @cwd
 
     # Set to observe config options
-    atom.config.observe 'linter-pylint.executable', => @updateCommand()
-    atom.config.observe 'linter-pylint.rcFile', => @updateCommand()
+    @executableListener = atom.config.observe 'linter-pylint.executable', => @updateCommand()
+    @rcFileListener = atom.config.observe 'linter-pylint.rcFile', => @updateCommand()
 
   destroy: ->
-    atom.config.unobserve 'linter-pylint.executable'
-    atom.config.unobserve 'linter-pylint.rcFile'
+    @executableListener.dispose()
+    @rcFileListener.dispose()
 
   # Sets the command based on config options
   updateCommand: ->

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "linter-pylint",
   "linter-package": true,
-  "activationEvents": [],
+  "activationCommands": [],
   "main": "./lib/init",
   "version": "0.2.1",
   "description": "Lint python on the fly, using pylint",


### PR DESCRIPTION
Deprecation Cop warns "Config::unobserve no longer does anything. Call .dispose() on the object returned by Config::observe instead." Updated to current API.

Deprecation Cop warns "Use activationCommands instead of activationEvents in your package.json". Updated to current API.