### PR TITLE
Optional display of pylint code, and human-readable version.

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -6,6 +6,14 @@ module.exports =
     rcFile:
       type: 'string'
       default: ''
+    showCodes:
+      description: "Shows the pylint code in linter messages (E1101, etc.)"
+      type: 'boolean'
+      default: false
+    showReadableCodes:
+      description: "Shows the human-readable pylint symbol in linter messages (e.g., unused-import for W0611)"
+      type: 'boolean'
+      default: false
 
   activate: ->
     console.log 'Linter-Pylint: package loaded,

--- a/lib/linter-pylint.coffee
+++ b/lib/linter-pylint.coffee
@@ -33,7 +33,21 @@ class LinterPylint extends Linter
   # Sets the command based on config options
   updateCommand: ->
     cmd = [atom.config.get 'linter-pylint.executable']
-    cmd.push "--msg-template='{line},{column},{category},{msg_id}:{msg}'"
+
+    showCodes = atom.config.get 'linter-pylint.showCodes'
+    showReadableCodes = atom.config.get 'linter-pylint.showReadableCodes'
+
+    msgCodes = ""
+    if showCodes or showReadableCodes
+      msgCodes = '('
+      if showCodes
+        msgCodes += '{msg_id}'
+        if showReadableCodes
+          msgCodes += ';'
+      if showReadableCodes
+        msgCodes += '{symbol}'
+      msgCodes += ') '
+    cmd.push "--msg-template='{line},{column},{category},{msg_id}:" + msgCodes + "{msg}'"
     cmd.push '--reports=n'
     cmd.push '--output-format=text'
 


### PR DESCRIPTION
Added display of pylint code, and human-readable (short) code, depending on new setting options. This solves issue #28.