### PR TITLE
Add option to configure the format of linter messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ This package will lint your opened Python-files in Atom, using [pylint](http://w
 ## Configuration
 * **Executable** Path to your pylint executable. This is useful if you have different versions of pylint for Python 2 and 3 or if you are using a virtualenv
 * **RC File** Path to a custom pylintrc
+* **Message Format** The format of the linter messages. It may include `%s`
+and `%i` for the Pylint human-readable and numeric message IDs.
 
 ## Other available linters
 There are other linters available - take a look at the linters [mainpage](https://github.com/AtomLinter/Linter).

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -10,7 +10,7 @@ module.exports =
         type: 'string'
         default: '%m'
         description:
-            'Format for PyLint messages, where %m is message, %i is the
+            'Format for Pylint messages, where %m is message, %i is the
             numeric mesasge ID (e.g. W0613) and %s is the human-readable
             message ID (e.g. unused-argument).'
 

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -6,6 +6,13 @@ module.exports =
     rcFile:
       type: 'string'
       default: ''
+    messageFormat:
+        type: 'string'
+        default: '%m'
+        description:
+            'Format for PyLint messages, where %m is message, %i is the
+            numeric mesasge ID (e.g. W0613) and %s is the human-readable
+            message ID (e.g. unused-argument).'
 
   activate: ->
     console.log 'Linter-Pylint: package loaded,

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -10,7 +10,7 @@ module.exports =
         type: 'string'
         default: '%m'
         description:
-            'Format for Pylint messages, where %m is message, %i is the
+            'Format for Pylint messages where %m is the message, %i is the
             numeric mesasge ID (e.g. W0613) and %s is the human-readable
             message ID (e.g. unused-argument).'
 

--- a/lib/linter-pylint.coffee
+++ b/lib/linter-pylint.coffee
@@ -34,8 +34,11 @@ class LinterPylint extends Linter
 
   # Sets the command based on config options
   updateCommand: ->
+    format = atom.config.get 'linter-pylint.messageFormat'
+    for pattern, value of {'%m': 'msg', '%i': 'msg_id', '%s': 'symbol'}
+        format = format.replace(new RegExp(pattern, 'g'), "{#{value}}")
     cmd = [atom.config.get 'linter-pylint.executable']
-    cmd.push "--msg-template='{line},{column},{category},{msg_id}:{msg}'"
+    cmd.push "--msg-template='{line},{column},{category},{msg_id}:#{format}'"
     cmd.push '--reports=n'
     cmd.push '--output-format=text'
 

--- a/lib/linter-pylint.coffee
+++ b/lib/linter-pylint.coffee
@@ -24,11 +24,13 @@ class LinterPylint extends Linter
     # Set to observe config options
     @executableListener = atom.config.observe 'linter-pylint.executable', => @updateCommand()
     @rcFileListener = atom.config.observe 'linter-pylint.rcFile', => @updateCommand()
+    @messageFormatListener = atom.config.observe 'linter-pylint.messageFormat', => @updateCommand()
 
   destroy: ->
     super
     @executableListener.dispose()
     @rcFileListener.dispose()
+    @messageFormat.dispose()
 
   # Sets the command based on config options
   updateCommand: ->


### PR DESCRIPTION
This is an alternative prospective fix for #28. It adds a new string setting, `messageFormat` which can contain format specifiers for the full Pylint message (`%m`), the message ID (`%i`) and the message symbol/human-readable ID (`%s`). The default value is set to `%m` which means the current default behaviour would be maintained.

This is [similar to what status-bar does](https://github.com/atom/status-bar/blob/07577349125d01cc81ff3f3a1da57d80c0a1497b/lib/main.coffee#L10) for formatting the cursor position. I think its nice for packages to not be too opinionated on how it should format things like this.

This PR would supersede #43.