### PR TITLE
Bugfix: Relative imports show errors

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -62,7 +62,7 @@ module.exports =
         return helpers.tempFile path.basename(file), activeEditor.getText(), (tmpFilename) =>
           projDir = @getProjDir(file)
           cwd = projDir
-          pythonPath = @pythonPath.replace(/%p/g, projDir)
+          pythonPath = @getPyPathWithRelImportDirs @pythonPath.replace(/%p/g, projDir), projDir, file
           env = Object.create process.env,
             PYTHONPATH:
               value: _.compact([process.env.PYTHONPATH, projDir, pythonPath]).join path.delimiter
@@ -92,6 +92,17 @@ module.exports =
   getProjDir: (filePath) ->
     _.find atom.project.getPaths(), (projPath) ->
       filePath.indexOf(projPath) == 0
+
+  # Add all directories in hierarchy between project dir and file dir to PYTHONPATH
+  # Required to support relative imports
+  getPyPathWithRelImportDirs: (_pythonPath, projDir, filePath) ->
+    pythonPath = _pythonPath
+    currentPath = path.dirname filePath
+    until currentPath is projDir or currentPath.length < projDir.length
+      pythonPath += ":#{currentPath}"
+      currentPath = path.dirname currentPath
+    return pythonPath
+
 
   filterWhitelistedErrors: (output) ->
     outputLines = _.compact output.split(os.EOL)


### PR DESCRIPTION
- Add relevant directories to `PYTHONPATH` such that relative imports are not marked as errors

Closes #58
### Testing
1. Checkout this PR ([instructions](https://gist.github.com/piscisaureus/3342247))
2. `cd` into your `linter-pylint` directory
3. `npm install`
4. Install into your dev packages - `apm link --dev`
5. Run atom in dev mode - `atom -d`

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/atomlinter/linter-pylint/61)

<!-- Reviewable:end -->
