### PR TITLE
Add linter name

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -55,6 +55,7 @@ module.exports =
 
   provideLinter: ->
     provider =
+      name: 'Pylint'
       grammarScopes: ['source.python']
       scope: 'file'
       lintOnFly: true


### PR DESCRIPTION
Specifies the linter name, allowing the `linter` package to display it if the user chooses to.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/atomlinter/linter-pylint/71)
<!-- Reviewable:end -->
