### PR TITLE
Fix getProjDir() for symbolic links

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -92,8 +92,7 @@ module.exports =
                 lintIssue
 
   getProjDir: (filePath) ->
-    _.find atom.project.getPaths(), (projPath) ->
-      filePath.indexOf(projPath) is 0
+    atom.project.relativizePath(filePath)[0]
 
   filterWhitelistedErrors: (output) ->
     outputLines = _.compact output.split(os.EOL)


### PR DESCRIPTION
`linter-pylint` wasn't finding my pylintrc from the project's root directory, and it turns out that `getProjDir()` was returning `undefined`.

It returns `undefined` if the project's root directory is a symbolic link to another directory. This PR should fix that.

The only difference I can see with the new `getProjDir()` is that now it returns `null` when there was no project path (it used to return `undefined`).