### PR TITLE
Fix travis yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: objective-c
 
 notifications:
   email:
-  on_success: never
-  on_failure: change
+    on_success: never
+    on_failure: change
 
 script: 'curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh | sh'


### PR DESCRIPTION
Fix the indentation of the `.travis.yml` file so it passes their linter.