### PR TITLE
actually use PYTHONPATH environment variable

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -79,6 +79,7 @@ module.exports =
           env = Object.create process.env,
             PYTHONPATH:
               value: _.compact([process.env.PYTHONPATH, projDir, pythonPath]).join path.delimiter
+              enumerable: true
           format = @messageFormat
           for pattern, value of {'%m': 'msg', '%i': 'msg_id', '%s': 'symbol'}
             format = format.replace(new RegExp(pattern, 'g'), "{#{value}}")


### PR DESCRIPTION
ChildProcess.spawn finally uses a for ... in loop
over the env object, which discards all non-enumerable
env attributes.

This should fix AtomLinter/linter-pylint#86 as well.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/atomlinter/linter-pylint/93)
<!-- Reviewable:end -->
