### PR TITLE
Update atom-linter and fix specs

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,14 +20,14 @@
     }
   },
   "dependencies": {
-    "atom-linter": "^3.3.7",
+    "atom-linter": "^3.3.9",
     "atom-package-deps": "^3.0.5",
     "lodash": "^3.10.1"
   },
   "devDependencies": {
     "coffeelint": "^1.14.1",
-    "eslint": "^1.9.0",
-    "babel-eslint": "^4.1.5",
+    "eslint": "^1.10.2",
+    "babel-eslint": "^4.1.6",
     "eslint-config-airbnb": "latest"
   },
   "package-deps": [

--- a/spec/linter-pylint-spec.js
+++ b/spec/linter-pylint-spec.js
@@ -49,7 +49,7 @@ describe('The pylint provider for Linter', () => {
         expect(messages[0].filePath).toMatch(/.+spec[\\\/]files[\\\/]bad\.py$/);
         expect(messages[0].range).toBeDefined();
         expect(messages[0].range.length).toEqual(2);
-        expect(messages[0].range).toEqual([[0, 0], [0, 3]]);
+        expect(messages[0].range).toEqual([[0, 0], [0, 4]]);
       });
     });
   });


### PR DESCRIPTION
`atom-linter` 3.3.8 included a fix to the range generation, require a version later than that and update the specs.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/atomlinter/linter-pylint/95)
<!-- Reviewable:end -->
