### PR TITLE
add \r to regex for atom-linter on windows

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -53,7 +53,7 @@ module.exports =
 
     @regex = '^(?<line>\\d+),(?<col>\\d+),\
                (?<type>\\w+),\
-               (\\w\\d+):(?<message>.*)$'
+               (\\w\\d+):(?<message>.*)\\r?$'
 
     @errorWhitelist = [
       /^No config file found, using default configuration$/


### PR DESCRIPTION
atom-linter's helper module and/or XRegExp doesn't deal well with windows newlines which ends up making the error list empty on windows with the latest version of pylint. I'm not quite sure what needs to be done on their end to prevent this from popping up but this workaround should solve the problem here without breaking anything.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/atomlinter/linter-pylint/97)
<!-- Reviewable:end -->
