### PR TITLE
show human-readable message ID by default

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -27,10 +27,10 @@ module.exports =
         of the current file.'
     messageFormat:
       type: 'string'
-      default: '%i %m'
+      default: '%m (%s)'
       description:
         'Format for Pylint messages where %m is the message, %i is the
-        numeric mesasge ID (e.g. W0613) and %s is the human-readable
+        numeric message ID (e.g. W0613) and %s is the human-readable
         message ID (e.g. unused-argument).'
 
   activate: ->


### PR DESCRIPTION
1. Numeric message ID is not useful.
2. User needs human-readable message ID to use in config and inline directives.

Format "%m (%s)" resembles pylint messages (as if it was called in command line).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/atomlinter/linter-pylint/127)
<!-- Reviewable:end -->
