### PR TITLE
Fix pylinting single file

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -105,7 +105,8 @@ module.exports =
                 lintIssue
 
   getProjDir: (filePath) ->
-    atom.project.relativizePath(filePath)[0]
+    projDir = atom.project.relativizePath(filePath)[0]
+    if projDir is filePath then path.parse(filePath).dir else projDir
 
   filterWhitelistedErrors: (output) ->
     outputLines = _.compact output.split(os.EOL)

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -106,7 +106,7 @@ module.exports =
 
   getProjDir: (filePath) ->
     projDir = atom.project.relativizePath(filePath)[0]
-    if projDir is filePath then path.parse(filePath).dir else projDir
+    if projDir is filePath then path.dirname(filePath) else projDir
 
   filterWhitelistedErrors: (output) ->
     outputLines = _.compact output.split(os.EOL)


### PR DESCRIPTION
as pointed out [here](https://github.com/AtomLinter/linter-pylint/issues/80#issuecomment-191534104), opening a single file leads to problems as projDir is set to `[...]/dir/my_file.py` instead of `[...]/dir`.

i'm barely familiar with atom packages or coffeescript so let me know if there's any better way to solved this

also it works on windows (64bit) - will test on ubuntu in a bit, don't have an OSX install to hand to test on that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/atomlinter/linter-pylint/136)
<!-- Reviewable:end -->
