### PR TITLE
allow relative import

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -3,10 +3,67 @@ helpers = require 'atom-linter'
 path = require 'path'
 _ = require 'lodash'
 os = require 'os'
-recursive = require 'recursive-readdir'
-fs = require 'fs'
-nodefs = require 'node-fs'
 tmp = require 'tmp'
+fs = require 'fs'
+
+tmp.setGracefulCleanup()
+
+readdir = (dir) ->
+  new Promise (resolve, reject) ->
+    fs.readdir dir, (err, files) ->
+      return reject err if err
+      resolve files
+
+stat = (file) ->
+  new Promise (resolve, reject) ->
+    fs.stat file, (err, stats) ->
+      return reject err if err
+      resolve stats
+
+mkdir = (folder) ->
+  new Promise (resolve, reject) ->
+    fs.mkdir folder, 0o750, (err) ->
+      return reject(err) if err
+      resolve()
+
+link = (to, linkname) ->
+  new Promise (resolve, reject) ->
+    fs.link to, linkname, (err) ->
+      return reject(err) if err
+      resolve()
+
+unlink = (linkname) ->
+  new Promise (resolve, reject) ->
+    fs.unlink linkname, (err) ->
+      return reject(err) if err
+      resolve()
+
+writeFile = (file, text) ->
+  new Promise (resolve, reject) ->
+    fs.writeFile file, text, (err) ->
+      return reject(err) if err
+      resolve()
+
+findFiles = (root) -> new Promise (resolve, reject) ->
+  readdir root
+  .then (files) ->
+
+    promises = []
+    for f in files
+
+      p = new Promise (resolve, reject) ->
+        filepath = path.join root, f
+        stat filepath
+        .then (stats) ->
+          resolve {'path': filepath, 'stats': stats}
+        .catch (err) -> reject err
+
+      promises.push p
+
+    Promise.all(promises).then (files) ->
+      resolve files
+    .catch (err) -> reject err
+  .catch (err) -> reject err
 
 module.exports =
   config:
@@ -38,7 +95,6 @@ module.exports =
         message ID (e.g. unused-argument).'
 
   activate: ->
-    tmp.setGracefulCleanup()
     require('atom-package-deps').install('linter-pylint')
     @subscriptions = new CompositeDisposable
     @subscriptions.add atom.config.observe 'linter-pylint.executable',
@@ -63,8 +119,74 @@ module.exports =
       /^No config file found, using default configuration$/
     ]
 
+    @projStatus = {}
+
   deactivate: ->
     @subscriptions.dispose()
+
+  getProjDir: (file) ->
+    atom.project.relativizePath(file)[0] or path.dirname file
+
+  getMessageFormat: ->
+    format = @messageFormat
+    for pattern, value of {'%m': 'msg', '%i': 'msg_id', '%s': 'symbol'}
+      format = format.replace(new RegExp(pattern, 'g'), "{#{value}}")
+    return format
+
+  getArgs: (file, filedir, pdir) ->
+    format = @getMessageFormat()
+    args = [
+      "--msg-template='{line},{column},{category},{msg_id}:#{format}'"
+      '--reports=n'
+      '--output-format=text'
+    ]
+    if @rcFile
+      rcFile = @rcFile.replace(/%p/g, pdir).replace(/%f/g, filedir)
+      args.push "--rcfile=#{rcFile}"
+    args.push file
+    return args
+
+  checkFile: (file, activeEditor) ->
+    origFile = file
+    pdir = @getProjDir file
+    from_root = path.dirname pdir
+
+    rel_file = path.relative(from_root, file)
+    rel_filedir = path.relative(from_root, path.dirname file)
+    rel_pdir = path.relative(from_root, pdir)
+
+    @projStatus[pdir]
+    .then (to_root) =>
+      filedir = path.join to_root.path, rel_filedir
+      file = path.join to_root.path, rel_file
+      pdir = path.join to_root.path, rel_pdir
+
+      cwd = @cwd.replace(/%f/g, filedir).replace(/%p/g, pdir)
+      executable = @executable.replace(/%p/g, pdir)
+
+      env = @createEnv filedir, pdir
+      args = @getArgs file, filedir, pdir
+      opts = {env: env, cwd: cwd, stream: 'both'}
+
+      return helpers.exec(executable, args, opts).then (data) =>
+        filteredErrors = @filterWhitelistedErrors(data.stderr)
+        throw new Error(filteredErrors) if filteredErrors
+        helpers.parse(data.stdout, @regex, {filePath: origFile})
+          .filter((lintIssue) -> lintIssue.type isnt 'info')
+          .map (lintIssue) =>
+            [[lineStart, colStart], [lineEnd, colEnd]] = lintIssue.range
+            if lineStart is lineEnd and colStart <= colEnd <= 0
+              return _.merge {}, lintIssue,
+                range: helpers.rangeFromLineNumber activeEditor, lineStart, colStart
+            lintIssue
+
+  createEnv: (filedir, pdir) ->
+    pythonPath = @pythonPath.replace(/%f/g, filedir).replace(/%p/g, pdir)
+    env = Object.create process.env,
+      PYTHONPATH:
+        value: _.compact([process.env.PYTHONPATH, pdir, filedir,
+                          pythonPath]).join path.delimiter
+        enumerable: true
 
   provideLinter: ->
     provider =
@@ -72,59 +194,103 @@ module.exports =
       grammarScopes: ['source.python']
       scope: 'file'
       lintOnFly: true
-      lint: (activeEditor) =>
+      lint: (activeEditor) => new Promise (resolve, reject) =>
         file = activeEditor.getPath()
-        data = activeEditor.getText()
-        projDir = @getProjDir(file) or path.dirname(file)
-        fileDir = path.dirname(file)
-        base_folder = tmp.dirSync {'unsafeCleanup': true}
-        recursive projDir, (err, files) ->
-          if err
-            throw err
-          for f in files
-            if /\.git/.test f or file is f
-              continue
-            folder = path.dirname f
-            nodefs.mkdirSync path.join(base_folder.name, folder), 0o777, true
-            fs.linkSync f, path.join(base_folder.name, f)
-        tmpFilename = path.join(base_folder.name, file)
-        nodefs.mkdirSync path.join(base_folder.name, path.dirname file), 0o777, true
-        fs.writeFileSync tmpFilename, data, {}, (err) ->
-          if err
-            throw err
-        cwd = @cwd.replace(/%f/g, fileDir).replace(/%p/g, projDir)
-        executable = @executable.replace(/%p/g, projDir)
-        pythonPath = @pythonPath.replace(/%f/g, fileDir).replace(/%p/g, projDir)
-        env = Object.create process.env,
-          PYTHONPATH:
-            value: _.compact([path.join(base_folder.name, projDir), process.env.PYTHONPATH, fileDir, projDir, pythonPath]).join path.delimiter
-            enumerable: true
-        format = @messageFormat
-        for pattern, value of {'%m': 'msg', '%i': 'msg_id', '%s': 'symbol'}
-          format = format.replace(new RegExp(pattern, 'g'), "{#{value}}")
-        args = [
-          "--msg-template='{line},{column},{category},{msg_id}:#{format}'"
-          '--reports=n'
-          '--output-format=text'
-        ]
-        if @rcFile
-          rcFile = @rcFile.replace(/%p/g, projDir).replace(/%f/g, fileDir)
-          args.push "--rcfile=#{rcFile}"
-        args.push tmpFilename
-        return helpers.exec(executable, args, {env: env, cwd: cwd, stream: 'both'}).then (data) =>
-          filteredErrors = @filterWhitelistedErrors(data.stderr)
-          throw new Error(filteredErrors) if filteredErrors
-          helpers.parse(data.stdout, @regex, {filePath: file})
-            .filter((lintIssue) -> lintIssue.type isnt 'info')
-            .map (lintIssue) ->
-              [[lineStart, colStart], [lineEnd, colEnd]] = lintIssue.range
-              if lineStart is lineEnd and colStart <= colEnd <= 0
-                return _.merge {}, lintIssue,
-                  range: helpers.rangeFromLineNumber activeEditor, lineStart, colStart
-              lintIssue
+        text = activeEditor.getText()
+        @prepareProj file
+        .then () =>
+          @unlink file
+        .then () =>
+          @writeText file, text
+        .then () =>
+          @checkFile file, activeEditor
+        .then (info) =>
+          @unlink(file).then(=> @link file).then(-> resolve info)
 
-  getProjDir: (filePath) ->
-    atom.project.relativizePath(filePath)[0]
+  link: (file) ->
+    pdir = @getProjDir file
+    from_root = path.dirname pdir
+    rel = path.relative(from_root, file)
+
+    @projStatus[pdir]
+    .then (to_root) ->
+      link path.join(from_root, rel), path.join(to_root.path, rel)
+
+  unlink: (file) ->
+    pdir = @getProjDir file
+    from_root = path.dirname pdir
+    rel = path.relative(from_root, file)
+
+    @projStatus[pdir]
+    .then (to_root) ->
+      unlink path.join(to_root.path, rel)
+
+
+  writeText: (file, text) ->
+    pdir = @getProjDir file
+    from_root = path.dirname pdir
+    rel = path.relative(from_root, file)
+
+    @projStatus[pdir]
+    .then (to_root) ->
+      fs.writeFile path.join(to_root.path, rel), text
+
+  prepareProj: (file) ->
+    pdir = @getProjDir file
+
+    return @projStatus[pdir] if pdir of @projStatus
+
+    @projStatus[pdir] = new Promise (resolve, reject) =>
+
+      @getTempDirectory 'linter-pylint_'
+      .then (tempDir) =>
+
+        new Promise (resolve, reject) =>
+          @duplicateFolder pdir, tempDir.path
+          .then () -> resolve tempDir
+          .catch (err) -> reject err
+
+      .then (tempDir) -> resolve tempDir
+      .catch (err) -> reject err
+
+    return @projStatus[pdir]
+
+  getTempDirectory: (prefix) ->
+    new Promise (resolve, reject) =>
+      tmp.dir { prefix, unsafeCleanup: true }, (err, directory, cleanup) =>
+        return reject err if err
+        @subscriptions.add { dispose: -> cleanup() }
+        resolve { path:directory, cleanup }
+
+  _duplicateFolder: (from_root, to_root, folder) -> new Promise (resolve, reject) =>
+    mkdir path.join to_root, folder
+    .then () =>
+      findFiles path.join(from_root, folder)
+      .then (files) =>
+        new Promise (resolve, reject) =>
+          promises = []
+          for file in files
+            rel = path.relative(from_root, file.path)
+            if file.stats.isDirectory()
+              do (rel) =>
+                promises.push @_duplicateFolder(from_root, to_root, rel)
+            else if file.stats.isFile()
+              do (rel) =>
+                promises.push link(file.path, path.join(to_root, rel))
+          Promise.all(promises)
+          .then () -> resolve()
+          .catch (err) -> reject err
+      .then () ->
+        resolve()
+      .catch (err) ->
+        reject err
+
+  duplicateFolder: (from, to) ->
+    from_root = path.dirname from
+    to_root = to
+    folder = path.basename from
+
+    @_duplicateFolder from_root, to_root, folder
 
   filterWhitelistedErrors: (output) ->
     outputLines = _.compact output.split(os.EOL)

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -78,22 +78,20 @@ module.exports =
         projDir = @getProjDir(file) or path.dirname(file)
         fileDir = path.dirname(file)
         base_folder = tmp.dirSync {'unsafeCleanup': true}
-        recursive projDir, (err, files) =>
-            if err
-                throw err
-            for f in files
-                if /\.git/.test f
-                    continue
-                if file == f
-                    continue
-                folder = path.dirname f
-                nodefs.mkdirSync path.join(base_folder.name, folder), 0o777, true
-                fs.linkSync f, path.join(base_folder.name, f)
+        recursive projDir, (err, files) ->
+          if err
+            throw err
+          for f in files
+            if /\.git/.test f or file is f
+              continue
+            folder = path.dirname f
+            nodefs.mkdirSync path.join(base_folder.name, folder), 0o777, true
+            fs.linkSync f, path.join(base_folder.name, f)
         tmpFilename = path.join(base_folder.name, file)
         nodefs.mkdirSync path.join(base_folder.name, path.dirname file), 0o777, true
-        fs.writeFileSync tmpFilename, data, {}, (err) =>
-            if err
-                throw err
+        fs.writeFileSync tmpFilename, data, {}, (err) ->
+          if err
+            throw err
         cwd = @cwd.replace(/%f/g, fileDir).replace(/%p/g, projDir)
         executable = @executable.replace(/%p/g, projDir)
         pythonPath = @pythonPath.replace(/%f/g, fileDir).replace(/%p/g, projDir)

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -3,6 +3,10 @@ helpers = require 'atom-linter'
 path = require 'path'
 _ = require 'lodash'
 os = require 'os'
+recursive = require 'recursive-readdir'
+fs = require 'fs'
+nodefs = require 'node-fs'
+tmp = require 'tmp'
 
 module.exports =
   config:
@@ -34,6 +38,7 @@ module.exports =
         message ID (e.g. unused-argument).'
 
   activate: ->
+    tmp.setGracefulCleanup()
     require('atom-package-deps').install('linter-pylint')
     @subscriptions = new CompositeDisposable
     @subscriptions.add atom.config.observe 'linter-pylint.executable',
@@ -69,40 +74,56 @@ module.exports =
       lintOnFly: true
       lint: (activeEditor) =>
         file = activeEditor.getPath()
-        return helpers.tempFile path.basename(file), activeEditor.getText(), (tmpFilename) =>
-          # default project dir to file directory if path cannot be determined
-          projDir = @getProjDir(file) or path.dirname(file)
-          fileDir = path.dirname(file)
-          cwd = @cwd.replace(/%f/g, fileDir).replace(/%p/g, projDir)
-          executable = @executable.replace(/%p/g, projDir)
-          pythonPath = @pythonPath.replace(/%f/g, fileDir).replace(/%p/g, projDir)
-          env = Object.create process.env,
-            PYTHONPATH:
-              value: _.compact([process.env.PYTHONPATH, fileDir, projDir, pythonPath]).join path.delimiter
-              enumerable: true
-          format = @messageFormat
-          for pattern, value of {'%m': 'msg', '%i': 'msg_id', '%s': 'symbol'}
-            format = format.replace(new RegExp(pattern, 'g'), "{#{value}}")
-          args = [
-            "--msg-template='{line},{column},{category},{msg_id}:#{format}'"
-            '--reports=n'
-            '--output-format=text'
-          ]
-          if @rcFile
-            rcFile = @rcFile.replace(/%p/g, projDir).replace(/%f/g, fileDir)
-            args.push "--rcfile=#{rcFile}"
-          args.push tmpFilename
-          return helpers.exec(executable, args, {env: env, cwd: cwd, stream: 'both'}).then (data) =>
-            filteredErrors = @filterWhitelistedErrors(data.stderr)
-            throw new Error(filteredErrors) if filteredErrors
-            helpers.parse(data.stdout, @regex, {filePath: file})
-              .filter((lintIssue) -> lintIssue.type isnt 'info')
-              .map (lintIssue) ->
-                [[lineStart, colStart], [lineEnd, colEnd]] = lintIssue.range
-                if lineStart is lineEnd and colStart <= colEnd <= 0
-                  return _.merge {}, lintIssue,
-                    range: helpers.rangeFromLineNumber activeEditor, lineStart, colStart
-                lintIssue
+        data = activeEditor.getText()
+        projDir = @getProjDir(file) or path.dirname(file)
+        fileDir = path.dirname(file)
+        base_folder = tmp.dirSync {'unsafeCleanup': true}
+        recursive projDir, (err, files) =>
+            if err
+                throw err
+            for f in files
+                if /\.git/.test f
+                    continue
+                if file == f
+                    continue
+                folder = path.dirname f
+                nodefs.mkdirSync path.join(base_folder.name, folder), 0o777, true
+                fs.linkSync f, path.join(base_folder.name, f)
+        tmpFilename = path.join(base_folder.name, file)
+        nodefs.mkdirSync path.join(base_folder.name, path.dirname file), 0o777, true
+        fs.writeFileSync tmpFilename, data, {}, (err) =>
+            if err
+                throw err
+        cwd = @cwd.replace(/%f/g, fileDir).replace(/%p/g, projDir)
+        executable = @executable.replace(/%p/g, projDir)
+        pythonPath = @pythonPath.replace(/%f/g, fileDir).replace(/%p/g, projDir)
+        env = Object.create process.env,
+          PYTHONPATH:
+            value: _.compact([path.join(base_folder.name, projDir), process.env.PYTHONPATH, fileDir, projDir, pythonPath]).join path.delimiter
+            enumerable: true
+        format = @messageFormat
+        for pattern, value of {'%m': 'msg', '%i': 'msg_id', '%s': 'symbol'}
+          format = format.replace(new RegExp(pattern, 'g'), "{#{value}}")
+        args = [
+          "--msg-template='{line},{column},{category},{msg_id}:#{format}'"
+          '--reports=n'
+          '--output-format=text'
+        ]
+        if @rcFile
+          rcFile = @rcFile.replace(/%p/g, projDir).replace(/%f/g, fileDir)
+          args.push "--rcfile=#{rcFile}"
+        args.push tmpFilename
+        return helpers.exec(executable, args, {env: env, cwd: cwd, stream: 'both'}).then (data) =>
+          filteredErrors = @filterWhitelistedErrors(data.stderr)
+          throw new Error(filteredErrors) if filteredErrors
+          helpers.parse(data.stdout, @regex, {filePath: file})
+            .filter((lintIssue) -> lintIssue.type isnt 'info')
+            .map (lintIssue) ->
+              [[lineStart, colStart], [lineEnd, colEnd]] = lintIssue.range
+              if lineStart is lineEnd and colStart <= colEnd <= 0
+                return _.merge {}, lintIssue,
+                  range: helpers.rangeFromLineNumber activeEditor, lineStart, colStart
+              lintIssue
 
   getProjDir: (filePath) ->
     atom.project.relativizePath(filePath)[0]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "linter-pylint",
   "main": "./lib/main",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "description": "Lint python on the fly, using pylint",
   "repository": "https://github.com/AtomLinter/linter-pylint",
@@ -20,17 +20,15 @@
     }
   },
   "dependencies": {
-    "atom-linter": "^4.6.1",
+    "atom-linter": "^4.7.0",
     "atom-package-deps": "^4.0.1",
-    "lodash": "^4.6.1",
-    "recursive-readdir": ">=2.0.0",
-    "node-fs": ">=0.1.7",
-    "tmp": ">=0.0.28"
+    "lodash": "^4.11.1",
+    "tmp": "^0.0.28"
   },
   "devDependencies": {
-    "coffeelint": "^1.15.0",
-    "eslint": "^2.4.0",
-    "eslint-config-airbnb": "^7.0.0"
+    "coffeelint": "^1.15.7",
+    "eslint": "^2.9.0",
+    "eslint-config-airbnb": "^8.0.0"
   },
   "package-deps": [
     "linter"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,10 @@
   "dependencies": {
     "atom-linter": "^4.6.1",
     "atom-package-deps": "^4.0.1",
-    "lodash": "^4.6.1"
+    "lodash": "^4.6.1",
+    "recursive-readdir": ">=2.0.0",
+    "node-fs": ">=0.1.7",
+    "tmp": ">=0.0.28"
   },
   "devDependencies": {
     "coffeelint": "^1.15.0",


### PR DESCRIPTION
This fix the relative import problem cited in https://github.com/AtomLinter/linter-pylint/issues/110

The idea is to mimic the entire directory structure of the project into the temporary folder via hard links, instead of only writing the file to be pylint checked to that temporary folder.

I welcome suggestions and I think this solution could be improved. It looks like the the created temporary folder is not being removed after the check, for example.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/atomlinter/linter-pylint/140)
<!-- Reviewable:end -->
