### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Plugin installs!](https://img.shields.io/apm/dm/linter-pylint.svg)](https://atom.io/packages/linter-pylint)
 [![Package version!](https://img.shields.io/apm/v/linter-pylint.svg?style=flat)](https://atom.io/packages/linter-pylint)
 
-This package will lint your opened Python-files in Atom, using [pylint](http://www.pylint.org/).
+This package will lint your opened Python-files in Atom, using [pylint](https://www.pylint.org/).
 
 ## Installation
 
@@ -26,7 +26,7 @@ This package will lint your opened Python-files in Atom, using [pylint](http://w
 * `%p` will fallback to the current file's directory (equivilent to `%f`) if no project directory can be determined.
 
 ## Other available linters
-There are other linters available - take a look at the linters [mainpage](https://github.com/AtomLinter/Linter).
+There are other linters available - take a look at the linters [mainpage](https://github.com/steelbrain/linter).
 
 ## Changelog
 
@@ -49,7 +49,7 @@ There are other linters available - take a look at the linters [mainpage](https:
 
 ### 0.1.3
  - Display pylint message ids
- - Fix debug mode [#9](https://github.com/AtomLinter/linter-pylint/issues/9)
+ - Fix debug mode [#9](https://github.com/AtomLinter/linter-pylint/pull/9)
  - Use project directory as cwd (works better with Atom projects)
 
 ### 0.1.2


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### GitHub Corrected URLs 
Was | Now 
--- | --- 
https://github.com/AtomLinter/Linter | https://github.com/steelbrain/linter 
https://github.com/AtomLinter/linter-pylint/issues/9 | https://github.com/AtomLinter/linter-pylint/pull/9 


### HTTPS Corrected URLs 
Was | Now 
--- | --- 
http://www.pylint.org/ | https://www.pylint.org/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/atomlinter/linter-pylint/150)
<!-- Reviewable:end -->
