### PR TITLE
Force environment encoding to UTF-8

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -105,6 +105,7 @@ export function provideLinter() {
           ].filter(x => !!x).join(delimiter),
           enumerable: true,
         },
+        LANG: { value: 'en_US.UTF-8', enumerable: true },
       });
 
       const args = [


### PR DESCRIPTION
On OSX (and possibly other systems) the environment is defaulting to `LANG=C`, which breaks pylint on UTF-8 files, until pylint fixes this bug force the environment to run in UTF-8 mode.

Fixes #135.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/atomlinter/linter-pylint/152)
<!-- Reviewable:end -->
