### PR TITLE
Fix a race condition

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -121,6 +121,10 @@ export function provideLinter() {
       return tempFile(basename(filePath), fileText, (tmpFileName) => {
         args.push(tmpFileName);
         return exec(execPath, args, { env, cwd, stream: 'both' }).then((data) => {
+          if (editor.getText() !== fileText) {
+            // Editor text was modified since the lint was triggered, tell Linter not to update
+            return null;
+          }
           const filteredErrors = filterWhitelistedErrors(data.stderr);
           if (filteredErrors) {
             throw new Error(filteredErrors);


### PR DESCRIPTION
When the editor text is modified after the lint was triggered, simply tell Linter to not update the results instead of attempting to mark the modified editor as this can lead to false positives on the invalid range check.

Fixes #165.
Fixes #147.
