### PR TITLE
Update CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ notifications:
 branches:
   only:
     - master
+    - /^greenkeeper/.*$/
 
 git:
   depth: 10

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
 
     - os: linux
       language: python
-      python: "3.5"
+      python: "3.6"
       env: ATOM_CHANNEL=beta
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,6 @@ matrix:
       python: "3.5"
       env: ATOM_CHANNEL=beta
 
-    - os: osx
-      language: generic
-      env: ATOM_CHANNEL=stable
-      before_install:
-        - brew update
-        - brew list python || brew install python
-
 install:
   - pip install pylint
 


### PR DESCRIPTION
Several updates to the Travis-CI configuration:

* Remove macOS testing as queue times are unusable
* Whitelist Greenkeeper branches so the "hidden" dependency update checks can run properly
* Update to Python 3.6 on the beta branch

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/atomlinter/linter-pylint/202)
<!-- Reviewable:end -->
