### PR TITLE
Update eslint-config-airbnb-base to v11.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   },
   "devDependencies": {
     "eslint": "^3.13.0",
-    "eslint-config-airbnb-base": "^11.0.1",
+    "eslint-config-airbnb-base": "^11.1.1",
     "eslint-plugin-import": "^2.2.0"
   },
   "package-deps": [

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "lazy-req": "^2.0.0"
   },
   "devDependencies": {
-    "eslint": "^3.13.0",
+    "eslint": "^3.16.1",
     "eslint-config-airbnb-base": "^11.1.1",
     "eslint-plugin-import": "^2.2.0"
   },


### PR DESCRIPTION
`eslint-config-airbnb-base@11.1.1` bumps the minimum `eslint` version so it needs to be explicitely bumped here.