### PR TITLE
Linter v2

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -10,65 +10,25 @@ import { CompositeDisposable } from 'atom';
 
 const lazyReq = require('lazy-req')(require);
 
-const { basename, delimiter, dirname } = lazyReq('path')(
-  'basename', 'delimiter', 'dirname',
-);
-const { exec, parse, generateRange, tempFile } = lazyReq('atom-linter')(
-  'exec', 'parse', 'generateRange', 'tempFile',
-);
+const { delimiter, dirname } = lazyReq('path')('delimiter', 'dirname');
+const { exec, generateRange } = lazyReq('atom-linter')('exec', 'generateRange');
 const os = lazyReq('os');
 
 // Some local variables
-let subscriptions;
 const errorWhitelist = [
   /^No config file found, using default configuration$/,
 ];
-const lineRegex = '(?<line>\\d+),(?<col>\\d+),(?<type>\\w+),(\\w\\d+):(?<message>.*)\\r?(\\n|$)';
 
-// Settings
-let executable;
-let rcFile;
-let messageFormat;
-let pythonPath;
-let workingDirectory;
-
-export function activate() {
-  require('atom-package-deps').install('linter-pylint');
-
-  subscriptions = new CompositeDisposable();
-
-  // FIXME: This should be executablePath, saved for a major version bump
-  subscriptions.add(atom.config.observe('linter-pylint.executable', (value) => {
-    executable = value;
-  }));
-  subscriptions.add(atom.config.observe('linter-pylint.rcFile', (value) => {
-    rcFile = value;
-  }));
-  subscriptions.add(atom.config.observe('linter-pylint.messageFormat', (value) => {
-    messageFormat = value;
-  }));
-  subscriptions.add(atom.config.observe('linter-pylint.pythonPath', (value) => {
-    pythonPath = value;
-  }));
-  subscriptions.add(atom.config.observe('linter-pylint.workingDirectory', (value) => {
-    workingDirectory = value.replace(delimiter, '');
-  }));
-}
-
-export function deactivate() {
-  subscriptions.dispose();
-}
-
-function getProjectDir(filePath) {
+const getProjectDir = (filePath) => {
   const atomProject = atom.project.relativizePath(filePath)[0];
   if (atomProject === null) {
-    // Default project dirextory to file directory if path cannot be determined
+    // Default project to file directory if project path cannot be determined
     return dirname(filePath);
   }
   return atomProject;
-}
+};
 
-function filterWhitelistedErrors(stderr) {
+const filterWhitelistedErrors = (stderr) => {
   // Split the input and remove blank lines
   const lines = stderr.split(os().EOL).filter(line => !!line);
   const filteredLines = lines.filter(line =>
@@ -76,73 +36,149 @@ function filterWhitelistedErrors(stderr) {
     !errorWhitelist.some(errorRegex => errorRegex.test(line)),
   );
   return filteredLines.join(os().EOL);
-}
+};
 
-export function provideLinter() {
-  return {
-    name: 'Pylint',
-    grammarScopes: ['source.python', 'source.python.django'],
-    scope: 'file',
-    lintOnFly: true,
-    lint: (editor) => {
-      const filePath = editor.getPath();
-      const fileDir = dirname(filePath);
-      const fileText = editor.getText();
-      const projectDir = getProjectDir(filePath);
-      const cwd = workingDirectory.replace(/%f/g, fileDir).replace(/%p/g, projectDir);
-      const execPath = executable.replace(/%p/g, projectDir);
-      let format = messageFormat;
-      const patterns = {
-        '%m': 'msg',
-        '%i': 'msg_id',
-        '%s': 'symbol',
-      };
-      Object.keys(patterns).forEach((pattern) => {
-        format = format.replace(new RegExp(pattern, 'g'), `{${patterns[pattern]}}`);
-      });
-      const env = Object.create(process.env, {
-        PYTHONPATH: {
-          value: [
-            process.env.PYTHONPATH, fileDir, projectDir,
-            pythonPath.replace(/%f/g, fileDir).replace(/%p/g, projectDir),
-          ].filter(x => !!x).join(delimiter),
-          enumerable: true,
-        },
-        LANG: { value: 'en_US.UTF-8', enumerable: true },
-      });
+const fixPathString = (pathString, fileDir, projectDir) => {
+  const string = pathString;
+  const fRstring = string.replace(/%f/g, fileDir);
+  const pRstring = fRstring.replace(/%p/g, projectDir);
+  return pRstring;
+};
 
-      const args = [
-        `--msg-template='{line},{column},{category},{msg_id}:${format}'`,
-        '--reports=n',
-        '--output-format=text',
-      ];
-      if (rcFile) {
-        args.push(`--rcfile=${rcFile.replace(/%p/g, projectDir).replace(/%f/g, fileDir)}`);
+const determineSeverity = (severity) => {
+  switch (severity) {
+    case 'error':
+    case 'warning':
+    case 'info':
+      return severity;
+    case 'convention':
+      return 'info';
+    default:
+      return 'warning';
+  }
+};
+
+export default {
+  activate() {
+    require('atom-package-deps').install('linter-pylint');
+
+    this.subscriptions = new CompositeDisposable();
+
+    this.subscriptions.add(atom.config.observe('linter-pylint.executablePath', (value) => {
+      this.executablePath = value;
+
+      // FIXME: Remove backwards compatibility in a future minor version
+      const oldPath = atom.config.get('linter-pylint.executable');
+      if (oldPath !== undefined) {
+        atom.config.unset('linter-pylint.executable');
+        if (oldPath !== 'pylint') {
+          // If the old config wasn't set to the default migrate it over
+          atom.config.set('linter-pylint.executablePath', oldPath);
+        }
       }
-      return tempFile(basename(filePath), fileText, (tmpFileName) => {
-        args.push(tmpFileName);
-        return exec(execPath, args, { env, cwd, stream: 'both' }).then((data) => {
-          if (editor.getText() !== fileText) {
-            // Editor text was modified since the lint was triggered, tell Linter not to update
-            return null;
-          }
-          const filteredErrors = filterWhitelistedErrors(data.stderr);
-          if (filteredErrors) {
-            throw new Error(filteredErrors);
-          }
-          return parse(data.stdout, lineRegex, { filePath })
-            .filter(issue => issue.type !== 'info')
-            .map((issue) => {
-              const [[lineStart, colStart], [lineEnd, colEnd]] = issue.range;
-              if (lineStart === lineEnd && (colStart <= colEnd || colEnd <= 0)) {
-                Object.assign(issue, {
-                  range: generateRange(editor, lineStart, colStart),
-                });
-              }
-              return issue;
-            });
+    }));
+    this.subscriptions.add(atom.config.observe('linter-pylint.rcFile', (value) => {
+      this.rcFile = value;
+    }));
+    this.subscriptions.add(atom.config.observe('linter-pylint.messageFormat', (value) => {
+      this.messageFormat = value;
+    }));
+    this.subscriptions.add(atom.config.observe('linter-pylint.pythonPath', (value) => {
+      this.pythonPath = value;
+    }));
+    this.subscriptions.add(atom.config.observe('linter-pylint.workingDirectory', (value) => {
+      this.workingDirectory = value.replace(delimiter, '');
+    }));
+    this.subscriptions.add(atom.config.observe('linter-pylint.disableTimeout', (value) => {
+      this.disableTimeout = value;
+    }));
+  },
+
+  deactivate() {
+    this.subscriptions.dispose();
+  },
+
+  provideLinter() {
+    return {
+      name: 'Pylint',
+      grammarScopes: ['source.python', 'source.python.django'],
+      scope: 'file',
+      lintsOnChange: false,
+      lint: async (editor) => {
+        const filePath = editor.getPath();
+        const fileDir = dirname(filePath);
+        const fileText = editor.getText();
+        const projectDir = getProjectDir(filePath);
+        const cwd = fixPathString(this.workingDirectory, fileDir, projectDir);
+        const execPath = fixPathString(this.executablePath, '', projectDir);
+        let format = this.messageFormat;
+        const patterns = {
+          '%m': 'msg',
+          '%i': 'msg_id',
+          '%s': 'symbol',
+        };
+        Object.keys(patterns).forEach((pattern) => {
+          format = format.replace(new RegExp(pattern, 'g'), `{${patterns[pattern]}}`);
         });
-      });
-    },
-  };
-}
+        const env = Object.create(process.env, {
+          PYTHONPATH: {
+            value: [
+              process.env.PYTHONPATH, fileDir, projectDir,
+              fixPathString(this.pythonPath, fileDir, projectDir),
+            ].filter(x => !!x).join(delimiter),
+            enumerable: true,
+          },
+          LANG: { value: 'en_US.UTF-8', enumerable: true },
+        });
+
+        const args = [
+          `--msg-template='{line},{column},{category},{msg_id}:${format}'`,
+          '--reports=n',
+          '--output-format=text',
+        ];
+        if (this.rcFile !== '') {
+          args.push(`--rcfile=${fixPathString(this.rcFile, fileDir, projectDir)}`);
+        }
+        args.push(filePath);
+
+        const execOpts = { env, cwd, stream: 'both' };
+        if (this.disableTimeout) {
+          execOpts.timeout = Infinity;
+        }
+
+        const data = await exec(execPath, args, execOpts);
+
+        if (editor.getText() !== fileText) {
+          // Editor text was modified since the lint was triggered, tell Linter not to update
+          return null;
+        }
+
+        const filteredErrors = filterWhitelistedErrors(data.stderr);
+        if (filteredErrors) {
+          // pylint threw an error we aren't ignoring!
+          throw new Error(filteredErrors);
+        }
+
+        const lineRegex = /(\d+),(\d+),(\w+),(\w\d+):(.*)\r?(?:\n|$)/g;
+        const toReturn = [];
+
+        let match = lineRegex.exec(data.stdout);
+        while (match !== null) {
+          const line = Number.parseInt(match[1], 10) - 1;
+          const column = Number.parseInt(match[2], 10);
+          const range = generateRange(editor, line, column);
+          const message = {
+            severity: determineSeverity(match[3]),
+            excerpt: match[5],
+            location: { file: filePath, range },
+          };
+
+          toReturn.push(message);
+          match = lineRegex.exec(data.stdout);
+        }
+
+        return toReturn;
+      },
+    };
+  },
+};

--- a/lib/main.js
+++ b/lib/main.js
@@ -171,6 +171,7 @@ export default {
             severity: determineSeverity(match[3]),
             excerpt: match[5],
             location: { file: filePath, range },
+            url: `http://pylint-messages.wikidot.com/messages:${match[4]}`,
           };
 
           toReturn.push(message);

--- a/lib/main.js
+++ b/lib/main.js
@@ -64,18 +64,18 @@ export default {
 
     this.subscriptions = new CompositeDisposable();
 
+    // FIXME: Remove backwards compatibility in a future minor version
+    const oldPath = atom.config.get('linter-pylint.executable');
+    if (oldPath !== undefined) {
+      atom.config.unset('linter-pylint.executable');
+      if (oldPath !== 'pylint') {
+        // If the old config wasn't set to the default migrate it over
+        atom.config.set('linter-pylint.executablePath', oldPath);
+      }
+    }
+
     this.subscriptions.add(atom.config.observe('linter-pylint.executablePath', (value) => {
       this.executablePath = value;
-
-      // FIXME: Remove backwards compatibility in a future minor version
-      const oldPath = atom.config.get('linter-pylint.executable');
-      if (oldPath !== undefined) {
-        atom.config.unset('linter-pylint.executable');
-        if (oldPath !== 'pylint') {
-          // If the old config wasn't set to the default migrate it over
-          atom.config.set('linter-pylint.executablePath', oldPath);
-        }
-      }
     }));
     this.subscriptions.add(atom.config.observe('linter-pylint.rcFile', (value) => {
       this.rcFile = value;
@@ -101,9 +101,9 @@ export default {
   provideLinter() {
     return {
       name: 'Pylint',
-      grammarScopes: ['source.python', 'source.python.django'],
       scope: 'file',
       lintsOnChange: false,
+      grammarScopes: ['source.python', 'source.python.django'],
       lint: async (editor) => {
         const filePath = editor.getPath();
         const fileDir = dirname(filePath);

--- a/package.json
+++ b/package.json
@@ -14,42 +14,54 @@
     "atom": ">=1.4.0 <2.0.0"
   },
   "configSchema": {
-    "executable": {
+    "executablePath": {
       "type": "string",
       "default": "pylint",
-      "description": "Command or path to executable. Use %p for current project directory (no trailing /)."
+      "description": "Command or full path to pylint. Use %p for current project directory (no trailing /).",
+      "order": 1
     },
     "pythonPath": {
       "type": "string",
       "default": "",
-      "description": "Paths to be added to $PYTHONPATH. Use %p for current project directory or %f for the directory of the current file."
+      "description": "Paths to be added to $PYTHONPATH. Use %p for current project directory or %f for the directory of the current file.",
+      "order": 1
     },
     "rcFile": {
       "type": "string",
       "default": "",
-      "description": "Path to pylintrc file. Use %p for the current project directory or %f for the directory of the current file."
+      "description": "Path to pylintrc file. Use %p for the current project directory or %f for the directory of the current file.",
+      "order": 2
     },
     "workingDirectory": {
       "type": "string",
       "default": "%p",
-      "description": "Directory pylint is run from. Use %p for the current project directory or %f for the directory of the current file."
+      "description": "Directory pylint is run from. Use %p for the current project directory or %f for the directory of the current file.",
+      "order": 2
     },
     "messageFormat": {
       "type": "string",
       "default": "%i %m",
-      "description": "Format for Pylint messages where %m is the message, %i is the numeric mesasge ID (e.g. W0613) and %s is the human-readable message ID (e.g. unused-argument)."
+      "description": "Format for Pylint messages where %m is the message, %i is the numeric mesasge ID (e.g. W0613) and %s is the human-readable message ID (e.g. unused-argument).",
+      "order": 2
+    },
+    "disableTimeout": {
+      "title": "Disable Execution Timeout",
+      "type": "boolean",
+      "default": false,
+      "description": "By default processes running longer than 10 seconds will be automatically terminated. Enable this option if you are getting messages about process execution timing out.",
+      "order": 3
     }
   },
   "providedServices": {
     "linter": {
       "versions": {
-        "1.0.0": "provideLinter"
+        "2.0.0": "provideLinter"
       }
     }
   },
   "dependencies": {
     "atom-linter": "^9.0.0",
-    "atom-package-deps": "^4.0.1",
+    "atom-package-deps": "^4.5.0",
     "lazy-req": "^2.0.0"
   },
   "devDependencies": {
@@ -58,7 +70,7 @@
     "eslint-plugin-import": "^2.2.0"
   },
   "package-deps": [
-    "linter"
+    "linter:2.0.0"
   ],
   "eslintConfig": {
     "extends": "airbnb-base",

--- a/spec/linter-pylint-spec.js
+++ b/spec/linter-pylint-spec.js
@@ -46,11 +46,20 @@ describe('The pylint provider for Linter', () => {
     it('verifies that message', () =>
       waitsForPromise(() =>
         lint(editor).then((messages) => {
-          expect(messages[0].type).toBe('convention');
-          expect(messages[0].html).not.toBeDefined();
-          expect(messages[0].text).toBe('C0111 Missing module docstring');
-          expect(messages[0].filePath).toBe(badPath);
-          expect(messages[0].range).toEqual([[0, 0], [0, 4]]);
+          expect(messages[0].severity).toBe('info');
+          expect(messages[0].excerpt).toBe('C0111 Missing module docstring');
+          expect(messages[0].location.file).toBe(badPath);
+          expect(messages[0].location.range).toEqual([[0, 0], [0, 4]]);
+
+          expect(messages[1].severity).toBe('warning');
+          expect(messages[1].excerpt).toBe('W0104 Statement seems to have no effect');
+          expect(messages[1].location.file).toBe(badPath);
+          expect(messages[1].location.range).toEqual([[0, 0], [0, 4]]);
+
+          expect(messages[2].severity).toBe('error');
+          expect(messages[2].excerpt).toBe("E0602 Undefined variable 'asfd'");
+          expect(messages[2].location.file).toBe(badPath);
+          expect(messages[2].location.range).toEqual([[0, 0], [0, 4]]);
         }),
       ),
     );

--- a/spec/linter-pylint-spec.js
+++ b/spec/linter-pylint-spec.js
@@ -5,7 +5,10 @@ import * as path from 'path';
 const goodPath = path.join(__dirname, 'files', 'good.py');
 const badPath = path.join(__dirname, 'files', 'bad.py');
 const emptyPath = path.join(__dirname, 'files', 'empty.py');
+
 const lint = require('../lib/main.js').provideLinter().lint;
+
+const wikiURLBase = 'http://pylint-messages.wikidot.com/messages:';
 
 describe('The pylint provider for Linter', () => {
   beforeEach(() => {
@@ -50,16 +53,19 @@ describe('The pylint provider for Linter', () => {
           expect(messages[0].excerpt).toBe('C0111 Missing module docstring');
           expect(messages[0].location.file).toBe(badPath);
           expect(messages[0].location.range).toEqual([[0, 0], [0, 4]]);
+          expect(messages[0].url).toBe(`${wikiURLBase}C0111`);
 
           expect(messages[1].severity).toBe('warning');
           expect(messages[1].excerpt).toBe('W0104 Statement seems to have no effect');
           expect(messages[1].location.file).toBe(badPath);
           expect(messages[1].location.range).toEqual([[0, 0], [0, 4]]);
+          expect(messages[1].url).toBe(`${wikiURLBase}W0104`);
 
           expect(messages[2].severity).toBe('error');
           expect(messages[2].excerpt).toBe("E0602 Undefined variable 'asfd'");
           expect(messages[2].location.file).toBe(badPath);
           expect(messages[2].location.range).toEqual([[0, 0], [0, 4]]);
+          expect(messages[2].url).toBe(`${wikiURLBase}E0602`);
         }),
       ),
     );


### PR DESCRIPTION
Update to Linter v2 and fix several aspects of the package including:
* Disable `lintOnChange`
  * Although a handy feature, until pylint allows specifying a filename for stdin input, the previous method of copying the current contents to a file simply caused more problems than it was worth.
* Add links to rule definitions on the [PyLint Messages Wiki](http://pylint-messages.wikidot.com)
* Rename `executable` option to `executablePath` to match other linters
  * Includes a backwards compatibility check where if the old setting had a configured value it is moved to the new one and the old one is unset.
* Add an option to allow disabling the execution timeout
* Code cleanup
  * Example output parsing for the RegEx: https://regex101.com/r/ZS8iUB/1

Fixes #204.
Fixes #200.
Likely fixes #199.
Fixes #153.
Fixes #110.
Fixes #77.
Fixes #57.