### PR TITLE
Rename range to position

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -166,11 +166,11 @@ export default {
         while (match !== null) {
           const line = Number.parseInt(match[1], 10) - 1;
           const column = Number.parseInt(match[2], 10);
-          const range = generateRange(editor, line, column);
+          const position = generateRange(editor, line, column);
           const message = {
             severity: determineSeverity(match[3]),
             excerpt: match[5],
-            location: { file: filePath, range },
+            location: { file: filePath, position },
             url: `http://pylint-messages.wikidot.com/messages:${match[4]}`,
           };
 

--- a/spec/linter-pylint-spec.js
+++ b/spec/linter-pylint-spec.js
@@ -52,19 +52,19 @@ describe('The pylint provider for Linter', () => {
           expect(messages[0].severity).toBe('info');
           expect(messages[0].excerpt).toBe('C0111 Missing module docstring');
           expect(messages[0].location.file).toBe(badPath);
-          expect(messages[0].location.range).toEqual([[0, 0], [0, 4]]);
+          expect(messages[0].location.position).toEqual([[0, 0], [0, 4]]);
           expect(messages[0].url).toBe(`${wikiURLBase}C0111`);
 
           expect(messages[1].severity).toBe('warning');
           expect(messages[1].excerpt).toBe('W0104 Statement seems to have no effect');
           expect(messages[1].location.file).toBe(badPath);
-          expect(messages[1].location.range).toEqual([[0, 0], [0, 4]]);
+          expect(messages[1].location.position).toEqual([[0, 0], [0, 4]]);
           expect(messages[1].url).toBe(`${wikiURLBase}W0104`);
 
           expect(messages[2].severity).toBe('error');
           expect(messages[2].excerpt).toBe("E0602 Undefined variable 'asfd'");
           expect(messages[2].location.file).toBe(badPath);
-          expect(messages[2].location.range).toEqual([[0, 0], [0, 4]]);
+          expect(messages[2].location.position).toEqual([[0, 0], [0, 4]]);
           expect(messages[2].url).toBe(`${wikiURLBase}E0602`);
         }),
       ),


### PR DESCRIPTION
This was missed in the update to Linter v2!

Fixes #206.