### PR TITLE
Remove hardcoded PYTHONPATH hack.

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -123,7 +123,7 @@ export default {
         const env = Object.create(process.env, {
           PYTHONPATH: {
             value: [
-              process.env.PYTHONPATH, fileDir, projectDir,
+              process.env.PYTHONPATH,
               fixPathString(this.pythonPath, fileDir, projectDir),
             ].filter(x => !!x).join(delimiter),
             enumerable: true,


### PR DESCRIPTION
The old behaviour can be restored by setting pythonPath to "%f:%p".

Since this behaviour interfers with correctly configured pylint, do not make it into a default, to prevent frustrating future users.

Fixes #104.