### PR TITLE
Update Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,10 +38,12 @@ git:
 
 sudo: false
 
+dist: trusty
+
 addons:
   apt:
     packages:
     - build-essential
-    - git
-    - libgnome-keyring-dev
     - fakeroot
+    - git
+    - libsecret-1-dev


### PR DESCRIPTION
Update the Travis CI configuration to use the Trusty image and an updated list of APT package dependencies.