### PR TITLE
Asyncify the specs

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
   "devDependencies": {
     "eslint": "^4.6.0",
     "eslint-config-airbnb-base": "^12.0.0",
-    "eslint-plugin-import": "^2.7.0"
+    "eslint-plugin-import": "^2.7.0",
+    "jasmine-fix": "^1.3.1"
   },
   "package-deps": [
     "linter:2.0.0"

--- a/spec/linter-pylint-spec.js
+++ b/spec/linter-pylint-spec.js
@@ -1,6 +1,8 @@
 'use babel';
 
 import * as path from 'path';
+// eslint-disable-next-line no-unused-vars
+import { it, fit, wait, beforeEach, afterEach } from 'jasmine-fix';
 
 const goodPath = path.join(__dirname, 'files', 'good.py');
 const badPath = path.join(__dirname, 'files', 'bad.py');
@@ -11,13 +13,9 @@ const { lint } = require('../lib/main.js').provideLinter();
 const wikiURLBase = 'http://pylint-messages.wikidot.com/messages:';
 
 describe('The pylint provider for Linter', () => {
-  beforeEach(() => {
-    waitsForPromise(() =>
-      Promise.all([
-        atom.packages.activatePackage('linter-pylint'),
-        atom.packages.activatePackage('language-python').then(() =>
-          atom.workspace.open(goodPath)),
-      ]));
+  beforeEach(async () => {
+    await atom.packages.activatePackage('linter-pylint');
+    await atom.packages.activatePackage('language-python');
   });
 
   it('should be in the packages list', () =>
@@ -26,51 +24,40 @@ describe('The pylint provider for Linter', () => {
   it('should be an active package', () =>
     expect(atom.packages.isPackageActive('linter-pylint')).toBe(true));
 
-  describe('checks bad.py and', () => {
-    let editor = null;
-    beforeEach(() => {
-      waitsForPromise(() =>
-        atom.workspace.open(badPath).then((openEditor) => {
-          editor = openEditor;
-        }));
-    });
+  it('checks bad.py and reports the correct results', async () => {
+    const editor = await atom.workspace.open(badPath);
+    const messages = await lint(editor);
 
-    it('finds at least one message', () =>
-      waitsForPromise(() =>
-        lint(editor).then(messages => expect(messages.length).toBeGreaterThan(0))));
+    expect(messages.length).toBe(3);
 
-    it('verifies that message', () =>
-      waitsForPromise(() =>
-        lint(editor).then((messages) => {
-          expect(messages[0].severity).toBe('info');
-          expect(messages[0].excerpt).toBe('C0111 Missing module docstring');
-          expect(messages[0].location.file).toBe(badPath);
-          expect(messages[0].location.position).toEqual([[0, 0], [0, 4]]);
-          expect(messages[0].url).toBe(`${wikiURLBase}C0111`);
+    expect(messages[0].severity).toBe('info');
+    expect(messages[0].excerpt).toBe('C0111 Missing module docstring');
+    expect(messages[0].location.file).toBe(badPath);
+    expect(messages[0].location.position).toEqual([[0, 0], [0, 4]]);
+    expect(messages[0].url).toBe(`${wikiURLBase}C0111`);
 
-          expect(messages[1].severity).toBe('warning');
-          expect(messages[1].excerpt).toBe('W0104 Statement seems to have no effect');
-          expect(messages[1].location.file).toBe(badPath);
-          expect(messages[1].location.position).toEqual([[0, 0], [0, 4]]);
-          expect(messages[1].url).toBe(`${wikiURLBase}W0104`);
+    expect(messages[1].severity).toBe('warning');
+    expect(messages[1].excerpt).toBe('W0104 Statement seems to have no effect');
+    expect(messages[1].location.file).toBe(badPath);
+    expect(messages[1].location.position).toEqual([[0, 0], [0, 4]]);
+    expect(messages[1].url).toBe(`${wikiURLBase}W0104`);
 
-          expect(messages[2].severity).toBe('error');
-          expect(messages[2].excerpt).toBe("E0602 Undefined variable 'asfd'");
-          expect(messages[2].location.file).toBe(badPath);
-          expect(messages[2].location.position).toEqual([[0, 0], [0, 4]]);
-          expect(messages[2].url).toBe(`${wikiURLBase}E0602`);
-        })));
+    expect(messages[2].severity).toBe('error');
+    expect(messages[2].excerpt).toBe("E0602 Undefined variable 'asfd'");
+    expect(messages[2].location.file).toBe(badPath);
+    expect(messages[2].location.position).toEqual([[0, 0], [0, 4]]);
+    expect(messages[2].url).toBe(`${wikiURLBase}E0602`);
   });
 
-  it('finds nothing wrong with an empty file', () => {
-    waitsForPromise(() =>
-      atom.workspace.open(emptyPath).then(editor =>
-        lint(editor).then(messages => expect(messages.length).toBe(0))));
+  it('finds nothing wrong with an empty file', async () => {
+    const editor = await atom.workspace.open(emptyPath);
+    const messages = await lint(editor);
+    expect(messages.length).toBe(0);
   });
 
-  it('finds nothing wrong with a valid file', () => {
-    waitsForPromise(() =>
-      atom.workspace.open(goodPath).then(editor =>
-        lint(editor).then(messages => expect(messages.length).toBe(0))));
+  it('finds nothing wrong with a valid file', async () => {
+    const editor = await atom.workspace.open(goodPath);
+    const messages = await lint(editor);
+    expect(messages.length).toBe(0);
   });
 });


### PR DESCRIPTION
Bring in `jasmine-fix` to allow the use of `async`/`await` in the specs and refactor them to take advantage of this.