### PR TITLE
Add support for defining multiple search locations for the rcfile.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ This package will lint your opened Python-files in Atom, using [pylint](https://
 * **Python Path** Paths to be added to the `PYTHONPATH` environment variable. Use `%p` for the current project
   directory (e.g. `%p/vendor`) or `%f` for the directory of the current
   file location.
-* **Rc File** Path to pylintrc file. Use `%p` for the current project directory or `%f` for the directory of the current
+* **Rc File** Path to pylintrc file. This field can specify multiple files by separating with `;`. The first valid
+  file path will be used. Use `%p` for the current project directory or `%f` for the directory of the current
   file location.
 * **Working Directory** Directory pylint is run from. Use `%p` for the current project directory or `%f` for the
   directory of the current file.

--- a/lib/main.js
+++ b/lib/main.js
@@ -8,6 +8,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies, import/extensions
 import { CompositeDisposable } from 'atom';
 import path from 'path';
+import fs from 'fs';
 
 const lazyReq = require('lazy-req')(require);
 
@@ -139,7 +140,16 @@ export default {
           '--output-format=text',
         ];
         if (this.rcFile !== '') {
-          args.push(`--rcfile=${fixPathString(this.rcFile, fileDir, projectDir)}`);
+          let realRcFile = null;
+          this.rcFile.split(";").forEach(line => {
+            let path = fixPathString(line, fileDir, projectDir);
+            if (!realRcFile && fs.existsSync(path) && fs.lstatSync(path).isFile()) {
+              realRcFile = path;
+            }
+          });
+
+          if (realRcFile)
+            args.push(`--rcfile=${realRcFile}`);
         }
         args.push(filePath);
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "rcFile": {
       "type": "string",
       "default": "",
-      "description": "Path to pylintrc file. Use %p for the current project directory or %f for the directory of the current file.",
+      "description": "Path to pylintrc file. Use %p for the current project directory or %f for the directory of the current file. Specify multiple files separate with ; and the first valid will be used.",
       "order": 2
     },
     "workingDirectory": {


### PR DESCRIPTION
This is implemented by splitting the rcFile field on ; and then
trying to find the first valid file path. When found that will be
used when calling pylint. This also avoids getting a error message
when the rc file is not around.