### PR TITLE
WIP: Use %PROJECT instead of %p in settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,17 +13,18 @@ This package will lint your opened Python-files in Atom, using [pylint](https://
 
 ## Configuration
 * **Executable** Path to your pylint executable. This is useful if you have different versions of pylint for Python 2
-  and 3 or if you are using a virtualenv. Use `%p` for the current project (no trailing /).
+  and 3 or if you are using a virtualenv. Use `%PROJECT` for the current project (no trailing /).
 * **Message Format** Format for Pylint messages where `%m` is the message, `%i` is the numeric message ID (e.g. W0613)
   and `%s` is the human-readable message ID (e.g. unused-argument).
-* **Python Path** Paths to be added to the `PYTHONPATH` environment variable. Use `%p` for the current project
-  directory (e.g. `%p/vendor`) or `%f` for the directory of the current
+* **Python Path** Paths to be added to the `PYTHONPATH` environment variable. Use `%PROJECT` for the current project
+  directory (e.g. `%PROJECT/vendor`) or `%f` for the directory of the current
   file location.
-* **Rc File** Path to pylintrc file. Use `%p` for the current project directory or `%f` for the directory of the current
-  file location.
-* **Working Directory** Directory pylint is run from. Use `%p` for the current project directory or `%f` for the
+* **Rc File** Path to pylintrc file. Use `%PROJECT` for the current project directory or `%f` for the directory of the
+  current file location.
+* **Working Directory** Directory pylint is run from. Use `%PROJECT` for the current project directory or `%f` for the
   directory of the current file.
-* `%p` will fallback to the current file's directory (equivilent to `%f`) if no project directory can be determined.
+* `%PROJECT` will fallback to the current file's directory (equivilent to `%f`) if no project directory can be
+  determined.
 
 ## Other available linters
 There are other linters available - take a look at the linters [mainpage](https://github.com/steelbrain/linter).

--- a/lib/main.js
+++ b/lib/main.js
@@ -40,11 +40,11 @@ const filterWhitelistedErrors = (stderr) => {
 };
 
 const fixPathString = (pathString, fileDir, projectDir) => {
-  const string = pathString;
-  const fRstring = string.replace(/%f/g, fileDir);
-  const hRstring = fRstring.replace(/%h/g, path.basename(projectDir));
-  const pRstring = hRstring.replace(/%p/g, projectDir);
-  return pRstring;
+  const string = pathString
+    .replace(/%f/g, fileDir)
+    .replace(/%PROJECT_NAME/g, path.basename(projectDir))
+    .replace(/%PROJECT/g, projectDir);
+  return string;
 };
 
 const determineSeverity = (severity) => {

--- a/package.json
+++ b/package.json
@@ -17,31 +17,31 @@
     "executablePath": {
       "type": "string",
       "default": "pylint",
-      "description": "Command or full path to pylint. Use %p for current project directory (no trailing /) or %h for current project name.",
+      "description": "Command or full path to pylint. Use `%PROJECT` for current project directory (no trailing /) or `%PROJECT_NAME` for current project name.",
       "order": 1
     },
     "pythonPath": {
       "type": "string",
       "default": "",
-      "description": "Paths to be added to $PYTHONPATH. Use %p for current project directory or %f for the directory of the current file.",
+      "description": "Paths to be added to $PYTHONPATH. Use `%PROJECT` for current project directory or `%f` for the directory of the current file.",
       "order": 1
     },
     "rcFile": {
       "type": "string",
       "default": "",
-      "description": "Path to pylintrc file. Use %p for the current project directory or %f for the directory of the current file.",
+      "description": "Path to pylintrc file. Use `%PROJECT` for the current project directory or `%f` for the directory of the current file.",
       "order": 2
     },
     "workingDirectory": {
       "type": "string",
-      "default": "%p",
-      "description": "Directory pylint is run from. Use %p for the current project directory or %f for the directory of the current file.",
+      "default": "%PROJECT",
+      "description": "Directory pylint is run from. Use `%PROJECT` for the current project directory or `%f` for the directory of the current file.",
       "order": 2
     },
     "messageFormat": {
       "type": "string",
       "default": "%i %m",
-      "description": "Format for Pylint messages where %m is the message, %i is the numeric mesasge ID (e.g. W0613) and %s is the human-readable message ID (e.g. unused-argument).",
+      "description": "Format for Pylint messages where `%m` is the message, `%i` is the numeric mesasge ID (e.g. W0613) and %s is the human-readable message ID (e.g. unused-argument).",
       "order": 2
     },
     "disableTimeout": {


### PR DESCRIPTION
Closes #133.

Some questions:
- As @Arcanemagus pointed out, this is a breaking change. Are there best practices about migrating user config in Atom packages? I can't seem to find anything.
- Since we are at it, should we rename the other vars as well (`%f`, `%i`, and `%m`)?