### PR TITLE
Allow specifying multiple executable paths

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -14,6 +14,7 @@ const lazyReq = require('lazy-req')(require);
 const { delimiter, dirname } = lazyReq('path')('delimiter', 'dirname');
 const { exec, generateRange } = lazyReq('atom-linter')('exec', 'generateRange');
 const os = lazyReq('os');
+const fs = lazyReq('fs');
 
 // Some local variables
 const errorWhitelist = [
@@ -45,6 +46,19 @@ const fixPathString = (pathString, fileDir, projectDir) => {
   const hRstring = fRstring.replace(/%h/g, path.basename(projectDir));
   const pRstring = hRstring.replace(/%p/g, projectDir);
   return pRstring;
+};
+
+const resolvePath = (fullPath) => {
+  const paths = fullPath.split(';');
+  if (paths.length === 1) {
+    return paths[0];
+  }
+  for (let i = 0; i < paths.length; i += 1) {
+    if (fs().existsSync(paths[i])) {
+      return paths[i];
+    }
+  }
+  throw Error(`Path cannot be found: ${fullPath}`);
 };
 
 const determineSeverity = (severity) => {
@@ -112,7 +126,7 @@ export default {
         const fileText = editor.getText();
         const projectDir = getProjectDir(filePath);
         const cwd = fixPathString(this.workingDirectory, fileDir, projectDir);
-        const execPath = fixPathString(this.executablePath, '', projectDir);
+        const execPath = resolvePath(fixPathString(this.executablePath, '', projectDir));
         let format = this.messageFormat;
         const patterns = {
           '%m': 'msg',

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "executablePath": {
       "type": "string",
       "default": "pylint",
-      "description": "Command or full path to pylint. Use %p for current project directory (no trailing /) or %h for current project name.",
+      "description": "Command or semicolon-separated list of paths to a binary (e.g. `/usr/local/bin/pylint`). Use `%p` for current project directory or `$h` for current project name (e.g. `%p/.venv/bin/pylint;/usr/bin/pylint`).",
       "order": 1
     },
     "pythonPath": {


### PR DESCRIPTION
Closes #231.

This patch was inspired by how this feature is implemented in AtomLinter/linter-flake8. It seems to work, I'm not very comfortable with `loadDeps`. I don't know if this is the right way to load dependencies in a linter. I tried with `lazyReq` without success.