### PR TITLE
Don't push rcfile into pylint if it is not present in file system

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -9,6 +9,7 @@
 import { CompositeDisposable } from 'atom';
 import path from 'path';
 
+const fs = require('fs');
 const lazyReq = require('lazy-req')(require);
 
 const { delimiter, dirname } = lazyReq('path')('delimiter', 'dirname');
@@ -138,7 +139,9 @@ export default {
           '--reports=n',
           '--output-format=text',
         ];
-        if (this.rcFile !== '') {
+        if (
+          this.rcFile !== '' &&
+          fs.existsSync(`${fixPathString(this.rcFile, fileDir, projectDir)}`)) {
           args.push(`--rcfile=${fixPathString(this.rcFile, fileDir, projectDir)}`);
         }
         args.push(filePath);

--- a/lib/main.js
+++ b/lib/main.js
@@ -141,7 +141,8 @@ export default {
         ];
         if (
           this.rcFile !== '' &&
-          fs.existsSync(`${fixPathString(this.rcFile, fileDir, projectDir)}`)) {
+          fs.existsSync(`${fixPathString(this.rcFile, fileDir, projectDir)}`)
+        ) {
           args.push(`--rcfile=${fixPathString(this.rcFile, fileDir, projectDir)}`);
         }
         args.push(filePath);


### PR DESCRIPTION
Fixes #251
When a .rcfile is specified in the package options, this PR checks if the referenced file does actually exist.

That can be useful if you specified a relative path for the file, e.g. `%f\.pylintrc`, but don't have a seperate rcfile in every directory, allowing the user to do this:
> "If this program requires a unusual rcfile, I can add it there, but in any other case, just use my default setting"