### PR TITLE
Add a special case of handling the E0001

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -174,10 +174,10 @@ export default {
           const line = Number.parseInt(match[1], 10) - 1;
           let column = Number.parseInt(match[2], 10);
           const errorCode = match[4];
-          if (errorCode == 'E0001') {
+          if (errorCode === 'E0001') {
             // E0001 stands for `Unexpected EOF while parsing`,
             // the column is placed after the last character.
-            column--;
+            column -= 1;
           }
           const position = generateRange(editor, line, column);
           const message = {

--- a/lib/main.js
+++ b/lib/main.js
@@ -172,13 +172,19 @@ export default {
         let match = lineRegex.exec(data.stdout);
         while (match !== null) {
           const line = Number.parseInt(match[1], 10) - 1;
-          const column = Number.parseInt(match[2], 10);
+          let column = Number.parseInt(match[2], 10);
+          const errorCode = match[4];
+          if (errorCode == 'E0001') {
+            // E0001 stands for `Unexpected EOF while parsing`,
+            // the column is placed after the last character.
+            column--;
+          }
           const position = generateRange(editor, line, column);
           const message = {
             severity: determineSeverity(match[3]),
             excerpt: match[5],
             location: { file: filePath, position },
-            url: `http://pylint-messages.wikidot.com/messages:${match[4]}`,
+            url: `http://pylint-messages.wikidot.com/messages:${errorCode}`,
           };
 
           toReturn.push(message);

--- a/spec/linter-pylint-spec.js
+++ b/spec/linter-pylint-spec.js
@@ -38,7 +38,7 @@ describe('The pylint provider for Linter', () => {
     expect(messages[0].excerpt).toMatch(/C011[14] Missing module docstring/);
     expect(messages[0].location.file).toBe(badPath);
     expect(messages[0].location.position).toEqual([[0, 0], [0, 4]]);
-    expect(messages[0].url).toBe(`${wikiURLBase}C0111`);
+    expect([`${wikiURLBase}C0111`, `${wikiURLBase}C0114`]).toContain(messages[0].url);
 
     expect(messages[1].severity).toBe('warning');
     expect(messages[1].excerpt).toBe('W0104 Statement seems to have no effect');

--- a/spec/linter-pylint-spec.js
+++ b/spec/linter-pylint-spec.js
@@ -35,7 +35,7 @@ describe('The pylint provider for Linter', () => {
     expect(messages.length).toBe(3);
 
     expect(messages[0].severity).toBe('info');
-    expect(messages[0].excerpt).toBe('C0111 Missing module docstring');
+    expect(messages[0].excerpt).toMatch(/C011[14] Missing module docstring/);
     expect(messages[0].location.file).toBe(badPath);
     expect(messages[0].location.position).toEqual([[0, 0], [0, 4]]);
     expect(messages[0].url).toBe(`${wikiURLBase}C0111`);


### PR DESCRIPTION
Consider the following Python code:
```python
def main():
```

Just like that, it is a syntax error, specifically, the one that PyLint reports as _Unexpected EOF while parsing_. And the line:column is placed just after the last character of the file, so `linter-pylint` fails with an error while trying to generate a range for the error.

This PR handles this case by decrementing the column to get it back inside the file.